### PR TITLE
PHP 7.1 compatibility

### DIFF
--- a/Classes/Domain/Model/FileReference.php
+++ b/Classes/Domain/Model/FileReference.php
@@ -40,7 +40,7 @@ class FileReference extends \TYPO3\CMS\Extbase\Domain\Model\FileReference {
 	/**
 	 * @param \TYPO3\CMS\Core\Resource\FileReference $originalResource
 	 */
-	public function setOriginalResource(\TYPO3\CMS\Core\Resource\FileReference $originalResource) {
+	public function setOriginalResource(\TYPO3\CMS\Core\Resource\ResourceInterface $originalResource) {
 		$this->originalResource = $originalResource;
 		$this->originalFileIdentifier = (int)$originalResource->getOriginalFile()->getUid();
 	}


### PR DESCRIPTION
use `\TYPO3\CMS\Core\Resource\ResourceInterface` or php 7.1 complains about 
mismatching interfaces